### PR TITLE
Address display management in asset_print_address fixed to return 0 i…

### DIFF
--- a/asset2.c
+++ b/asset2.c
@@ -116,8 +116,8 @@ int asset_print_address(va_list args)
 	*ptr = '\0';
 	if (n == 0)
 	{
-		write(1, "0x0", 3);
-		return (5);
+		write(1, "0x0", 5);
+		return (0);
 	}
 
 	do {


### PR DESCRIPTION
…nstead of 5 when the address is null.