### PR TITLE
Address display management in asset_print_address fixed to return 5 i…

### DIFF
--- a/asset2.c
+++ b/asset2.c
@@ -117,7 +117,7 @@ int asset_print_address(va_list args)
 	if (n == 0)
 	{
 		write(1, "(nil)", 5);
-		return (0);
+		return (5);
 	}
 
 	do {


### PR DESCRIPTION
…nstead of 0 when the address is null.